### PR TITLE
(11) Migrate rspec tests from :params to hiera

### DIFF
--- a/dist/profile/.fixtures.yml
+++ b/dist/profile/.fixtures.yml
@@ -4,7 +4,7 @@ fixtures:
   repositories:
     apache: 'git://github.com/puppetlabs/puppetlabs-apache'
     bind: 'git://github.com/thias/puppet-bind'
-    certs: 'git://github.com/rnelson0/certs'
+    certs: 'git://github.com/rnelson0/puppet-certs'
     concat:
       repo: 'git://github.com/puppetlabs/puppetlabs-concat'
       ref: '1.2.0'
@@ -14,6 +14,7 @@ fixtures:
     firewall: 'git://github.com/puppetlabs/puppetlabs-firewall'
     git: 'git://github.com/puppetlabs/puppetlabs-git'
     inifile: 'git://github.com/puppetlabs/puppetlabs-inifile'
+    local_user: 'git://github.com/rnelson0/puppet-local_user'
     lvm: 'git://github.com/puppetlabs/puppetlabs-lvm'
     mysql: 'git://github.com/puppetlabs/puppetlabs-mysql'
     ntp: 'git://github.com/puppetlabs/puppetlabs-ntp'

--- a/dist/profile/.gitignore
+++ b/dist/profile/.gitignore
@@ -1,6 +1,7 @@
 .*.sw?
 /pkg
-/spec/fixtures
+/spec/fixtures/*
+!/spec/fixtures/hiera*
 /.rspec_system
 /.vagrant
 /.bundle

--- a/dist/profile/spec/classes/apache_spec.rb
+++ b/dist/profile/spec/classes/apache_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 describe 'profile::apache', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,8 +8,7 @@ describe 'profile::apache', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::apache') }

--- a/dist/profile/spec/classes/base_spec.rb
+++ b/dist/profile/spec/classes/base_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 describe 'profile::base', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,14 +8,19 @@ describe 'profile::base', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
-    it { is_expected.to create_class('profile::linuxfw') }
     it { is_expected.to create_class('profile::base') }
-    it { is_expected.to create_class('ntp') }
-    it { is_expected.to create_class('ssh::server') }
-    it { is_expected.to create_class('ssh::client') }
+    it { is_expected.to contain_class('profile::linuxfw') }
+    it { is_expected.to contain_class('ssh::server') }
+    it { is_expected.to contain_class('ssh::client') }
+    it { is_expected.to contain_class('ntp') }
+    it { is_expected.to contain_ssh_authorized_key('testkey') }
+    it { is_expected.to contain_yumrepo('lab') }
+    it { is_expected.to contain_exec('shosts.equiv') }
+    it { is_expected.to contain_class('sudo') }
+    it { is_expected.to contain_sudo__conf('wheel') }
+    it { is_expected.to contain_local_user('testuser') }
   end
 end

--- a/dist/profile/spec/classes/build_spec.rb
+++ b/dist/profile/spec/classes/build_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 describe 'profile::build' do
-  let :facts do
-  {
+  let :facts do {
     :clientcert => 'build',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     let :facts do
@@ -12,6 +10,7 @@ describe 'profile::build' do
         :is_pe => false,
       })
     end
+
     it { should create_class('profile::build') }
     it { should contain_class('rvm') }
     it { should contain_rvm_system_ruby('ruby-1.9.3-p511') }

--- a/dist/profile/spec/classes/dhcp_spec.rb
+++ b/dist/profile/spec/classes/dhcp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'profile::dhcp', :type => :class do
-  let :facts do
-  {
+  let :facts do {
+    :clientcert             => 'dhcp',
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,8 +9,7 @@ describe 'profile::dhcp', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::dhcp') }

--- a/dist/profile/spec/classes/dns_spec.rb
+++ b/dist/profile/spec/classes/dns_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 describe 'profile::dns', :type => :class do
+  let :facts do {
+    :clientcert => 'dns',
+  } end
+
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::dns') }
     it { is_expected.to contain_package('bind') }

--- a/dist/profile/spec/classes/hiera_spec.rb
+++ b/dist/profile/spec/classes/hiera_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 describe 'profile::hiera', :type => :class do
+
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::hiera') }
     it { is_expected.to create_package('hiera') }

--- a/dist/profile/spec/classes/linuxfw/linuxfw_post_spec.rb
+++ b/dist/profile/spec/classes/linuxfw/linuxfw_post_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 describe 'profile::linuxfw::post', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :kernel                 => 'Linux',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::linuxfw::post') }

--- a/dist/profile/spec/classes/linuxfw/linuxfw_pre_spec.rb
+++ b/dist/profile/spec/classes/linuxfw/linuxfw_pre_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 describe 'profile::linuxfw::pre', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :kernel                 => 'Linux',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::linuxfw::pre') }

--- a/dist/profile/spec/classes/linuxfw_spec.rb
+++ b/dist/profile/spec/classes/linuxfw_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 describe 'profile::linuxfw', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :kernel                 => 'Linux',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::linuxfw') }

--- a/dist/profile/spec/classes/mysql/mysql_client_spec.rb
+++ b/dist/profile/spec/classes/mysql/mysql_client_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 describe 'profile::mysql::client', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :osfamily               => 'RedHat',
     :operatingsystem        => 'RedHat',
     :operatingsystemrelease => '6',

--- a/dist/profile/spec/classes/mysql/mysql_server_spec.rb
+++ b/dist/profile/spec/classes/mysql/mysql_server_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 describe 'profile::mysql::server', :type => :class do
-  let :facts do
-  {
+  let :facts do {
+    :clientcert             => 'mysql',
     :osfamily               => 'RedHat',
     :operatingsystem        => 'RedHat',
     :operatingsystemrelease => '6',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::mysql::server') }

--- a/dist/profile/spec/classes/phpmyadmin_spec.rb
+++ b/dist/profile/spec/classes/phpmyadmin_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'profile::phpmyadmin', :type => :class do
-  let :facts do
-  {
+  let :facts do {
+    :clientcert             => 'phpmyadmin',
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,16 +9,9 @@ describe 'profile::phpmyadmin', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with dbpass and cname' do
-    let (:params) do
-    {
-      :cname  => 'phpmyadmin.example.com',
-    }
-    end
-
     it { is_expected.to create_class('profile::phpmyadmin') }
     it { is_expected.to contain_package('phpMyAdmin') }
     it { is_expected.to contain_selboolean('httpd_can_network_connect_db') }

--- a/dist/profile/spec/classes/puppet_master.rb
+++ b/dist/profile/spec/classes/puppet_master.rb
@@ -1,12 +1,10 @@
 require 'spec_helper'
 describe 'profile::puppet_master', :type => :class do
-  let (:facts) do
-  {
+  let :facts do {
     :osfamily               => 'RedHat',
     :operatingsystemrelease => '6.5',
     :concat_basedir         => '/dne/',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::puppet_master') }

--- a/dist/profile/spec/classes/puppetdb_spec.rb
+++ b/dist/profile/spec/classes/puppetdb_spec.rb
@@ -1,11 +1,9 @@
 require 'spec_helper'
 describe 'profile::puppetdb', :type => :class do
-  let :facts do
-  {
+  let :facts do {
     :osfamily               => 'RedHat',
     :concat_basedir         => '/dne',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::puppetdb') }

--- a/dist/profile/spec/classes/tftp_spec.rb
+++ b/dist/profile/spec/classes/tftp_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'profile::tftp', :type => :class do
-  let :facts do
-  {
+  let :facts do {
+    :clientcert             => 'tftp',
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,8 +9,7 @@ describe 'profile::tftp', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
     it { is_expected.to create_class('profile::tftp') }

--- a/dist/profile/spec/classes/yumrepo_spec.rb
+++ b/dist/profile/spec/classes/yumrepo_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'profile::yumrepo', :type => :class do
-  let :facts do
-  {
+  let :facts do {
+    :clientcert => 'yum',
     :id                     => 'root',
     :kernel                 => 'Linux',
     :osfamily               => 'RedHat',
@@ -9,16 +9,9 @@ describe 'profile::yumrepo', :type => :class do
     :operatingsystemrelease => '6',
     :concat_basedir         => '/dne',
     :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-  }
-  end
+  } end
 
   context 'with defaults for all parameters' do
-    let :facts do
-      super().merge({
-	:clientcert => 'yum',
-      })
-    end
-
     it { is_expected.to create_class('profile::yumrepo') }
     it { is_expected.to contain_file('/repodir') }
     it { is_expected.to contain_createrepo('testrepo') }

--- a/dist/profile/spec/fixtures/hieradata/default.yaml
+++ b/dist/profile/spec/fixtures/hieradata/default.yaml
@@ -1,62 +1,14 @@
 ---
-bind_server_confs:
-  '/etc/named.conf':
-    listen_on_addr:
-      - '127.0.0.1'
-    allow_query:
-      - 'localhost'
-bind_server_files:
-  'named.test':
-    source: 'name.test'
-sshvpn_hosts:
-  sample:
-    ensure  : 'present'
-    comment : 'Sample host'
-    ip      : '127.0.0.255'
-dhcp_server_subnets:
-  '10.0.0.0':
-    broadcast   : '10.0.0.255'
-    netmask     : '255.255.255.0'
-    routers     : '10.0.0.1'
-    range_begin : '10.0.0.100'
-    range_end   : '10.0.0.150'
-    dns_servers :
-      - '10.0.0.1'
-dhcp_server_hosts:
-  sample:
-    address:   10.0.0.254
-    hwaddress: 00:00:00:00:00:0a
-mysql::server::root_password: 'strongpassword'
-mysql::server::users:
-  'someuser@localhost':
-    ensure        : 'present'
-    password_hash : 'SOMETHING'
-mysql::server::grants:
-  'someuser@localhost/somedb.*':
-    ensure     : 'present'
-    options    : ['GRANT']
-    privileges : ['SELECT', 'INSERT', 'UPDATE', 'DELETE']
-    table      : 'somedb.*'
-    user       : 'someuser@localhost'
-mysql::server::databases:
-  somedb:
-    ensure  : 'present'
-    charset : 'utf8'
-mysql::server::backup::backupuser        : 'dbbackup'
-mysql::server::backup::backuppassword    : 'password'
-mysql::server::backup::backupdir         : '/data/mysql/backups'
-mysql::server::backup::backupcompress    : 'true'
-mysql::server::backup::backuprotate      : 90
-mysql::server::backup::file_per_database : 'true'
-mysql::server::backup::time              : ['*', '00']
-profile::phpmyadmin::servers:
-  test:
-    host: '1.2.3.4'
-    user: 'phpMyAdmin'
-    pass: 'password'
-tftp::files:
-  pxelinux.0:
-    source: puppet://modules/test/pxelinux.0
+ssh_authorized_keys:
+  testkey: {}
 yumrepo_name: 'el-6.5'
 yumrepo_desc: 'EL 6.5'
 yumrepo_url: 'http://yum.example/el-6.5/'
+local_users:
+  testuser:
+    state: 'present'
+    comment: 'Test User'
+    groups:
+      - 'group1'
+      - 'group2'
+    password: 'encryptedstring'

--- a/dist/profile/spec/fixtures/hieradata/dhcp.yaml
+++ b/dist/profile/spec/fixtures/hieradata/dhcp.yaml
@@ -1,0 +1,14 @@
+---
+dhcp_server_subnets:
+  '10.0.0.0':
+    broadcast   : '10.0.0.255'
+    netmask     : '255.255.255.0'
+    routers     : '10.0.0.1'
+    range_begin : '10.0.0.100'
+    range_end   : '10.0.0.150'
+    dns_servers :
+      - '10.0.0.1'
+dhcp_server_hosts:
+  sample:
+    address:   10.0.0.254
+    hwaddress: 00:00:00:00:00:0a

--- a/dist/profile/spec/fixtures/hieradata/dns.yaml
+++ b/dist/profile/spec/fixtures/hieradata/dns.yaml
@@ -1,0 +1,10 @@
+---
+bind_server_confs:
+  '/etc/named.conf':
+    listen_on_addr:
+      - '127.0.0.1'
+    allow_query:
+      - 'localhost'
+bind_server_files:
+  'named.test':
+    source: 'name.test'

--- a/dist/profile/spec/fixtures/hieradata/mysql.yaml
+++ b/dist/profile/spec/fixtures/hieradata/mysql.yaml
@@ -1,0 +1,24 @@
+---
+mysql::server::root_password: 'strongpassword'
+mysql::server::users:
+  'someuser@localhost':
+    ensure        : 'present'
+    password_hash : 'SOMETHING'
+mysql::server::grants:
+  'someuser@localhost/somedb.*':
+    ensure     : 'present'
+    options    : ['GRANT']
+    privileges : ['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+    table      : 'somedb.*'
+    user       : 'someuser@localhost'
+mysql::server::databases:
+  somedb:
+    ensure  : 'present'
+    charset : 'utf8'
+mysql::server::backup::backupuser        : 'dbbackup'
+mysql::server::backup::backuppassword    : 'password'
+mysql::server::backup::backupdir         : '/data/mysql/backups'
+mysql::server::backup::backupcompress    : 'true'
+mysql::server::backup::backuprotate      : 90
+mysql::server::backup::file_per_database : 'true'
+mysql::server::backup::time              : ['*', '00']

--- a/dist/profile/spec/fixtures/hieradata/phpmyadmin.yaml
+++ b/dist/profile/spec/fixtures/hieradata/phpmyadmin.yaml
@@ -1,0 +1,7 @@
+---
+profile::phpmyadmin::cname: 'phpmyadmin.example.com'
+profile::phpmyadmin::servers:
+  test:
+    host: '1.2.3.4'
+    user: 'phpMyAdmin'
+    pass: 'password'

--- a/dist/profile/spec/fixtures/hieradata/tftp.yaml
+++ b/dist/profile/spec/fixtures/hieradata/tftp.yaml
@@ -1,0 +1,4 @@
+---
+tftp::files:
+  pxelinux.0:
+    source: puppet://modules/test/pxelinux.0


### PR DESCRIPTION
  Params data now in hiera.
  Rspec files have consistent formatting for referencing facts.
  Rspec hiera references are via the clientcert fact.
  Individual hiera files for each clientcert present.
  .gitignore ignores all spec fixtures except hiera and its data.

Closes #11.
