### PR TITLE
needed to specify puppetdb version

### DIFF
--- a/master.pp
+++ b/master.pp
@@ -4,7 +4,14 @@ Package {
 
 include ::epel
 Yumrepo<| |> -> Package <| |>
-include ::puppetdb
+
+# https://github.com/puppetlabs/puppetlabs-puppetdb#upgrading-from-4x-to-version-5x
+class { '::puppetdb::globals':
+  version => '2.3.7-1.el6',
+}
+include '::puppetdb'
+
+
 class { '::puppet::master':
   storeconfigs => true,
   environments => directory,


### PR DESCRIPTION
Need your opinion on this one. I am not happy with how I hardcoded `version` param, especially the el6 portion of it.

This PR is a fix for what we were talking the other day. I mentioned that I can't `./bootstrap.sh` successfully because of this "termini vs. terminus" problem. You linked me to some info [HERE](https://github.com/puppetlabs/puppetlabs-puppetdb#upgrading-from-4x-to-version-5x). Short story is: if you are going to use puppetlabs-puppetdb v5.x with PuppetDB 2.x, then we have to specify the `version` param.

It seems that our other options are to:
1. Downgrade to PuppetDB 4.x module to use with PuppetDB 2.x
2. Consider supporting PuppetDB 3.x which probably needs Puppet 4.x
