### PR TITLE
added puppet /etc/hosts entry for puppet agent -t to work

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,7 @@ puppet module install --modulepath=/root/bootstrap/modules hunner/hiera --versio
 puppet apply --modulepath=/root/bootstrap/modules master.pp && \
 puppet apply --modulepath=/root/bootstrap/modules hiera.pp && \
 puppet apply --modulepath=/root/bootstrap/modules r10k_installation.pp && \
+puppet apply -e 'host { "puppet": ip => "127.0.1.1" }'
 # If everything went well, deploy using r10k
 r10k deploy environment -p
 


### PR DESCRIPTION
After `./bootstrap.sh`, `puppet agent -t` won't won't work because it can't resolve the host "puppet." This PR adds a line to /etc/hosts so we can resolve puppet => localhost
