### PR TITLE
added github.com host key

### DIFF
--- a/r10k_installation.pp
+++ b/r10k_installation.pp
@@ -2,6 +2,11 @@ Package {
   allow_virtual => true,
 }
 
+sshkey { 'github.com':
+  type => 'ssh-rsa',
+  key  => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==',
+}
+
 class { 'r10k':
   version           => '1.5.1',
   sources           => {
@@ -13,3 +18,4 @@ class { 'r10k':
   },
   manage_modulepath => false
 }
+


### PR DESCRIPTION
One last PR for a fully successful `./bootstrap.sh` from scratch.

This PR fixes `r10k_installation.pp` failing on a clean VM, because github.com's ssh host key has not yet been added to known_hosts file
